### PR TITLE
Support creating indexes before loading data

### DIFF
--- a/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/SpecializedElementFactory.java
+++ b/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/SpecializedElementFactory.java
@@ -20,20 +20,18 @@ package org.apache.tinkerpop.gremlin.tinkergraph.structure;
 
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 
-import java.util.Map;
-
 /* To make use of specialized elements (for better memory/performance characteristics), you need to
  * create instances of these factories and register them with TinkerGraph. That way it will instantiate
  * your specialized elements rather than generic ones. */
 public class SpecializedElementFactory {
     public interface ForVertex<T extends SpecializedTinkerVertex, IdType> {
         public abstract String forLabel();
-        public abstract T createVertex(IdType id, TinkerGraph graph, Map<String, Object> keyValueMap);
+        public abstract T createVertex(IdType id, TinkerGraph graph);
     }
 
     public interface ForEdge<T extends SpecializedTinkerEdge, IdType> {
         public abstract String forLabel();
-        public abstract T createEdge(IdType id, Vertex outVertex, Vertex inVertex, Map<String, Object> keyValueMap);
+        public abstract T createEdge(IdType id, Vertex outVertex, Vertex inVertex);
     }
 }
 

--- a/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/SpecializedTinkerEdge.java
+++ b/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/SpecializedTinkerEdge.java
@@ -18,8 +18,10 @@
  */
 package org.apache.tinkerpop.gremlin.tinkergraph.structure;
 
+import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Property;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.apache.tinkerpop.gremlin.structure.util.ElementHelper;
 import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils;
 
 import java.util.*;
@@ -59,7 +61,12 @@ public abstract class SpecializedTinkerEdge<IdType> extends TinkerEdge {
 
     @Override
     public <V> Property<V> property(String key, V value) {
-        return updateSpecificProperty(key, value);
+        if (this.removed) throw elementAlreadyRemoved(Edge.class, id);
+        ElementHelper.validateProperty(key, value);
+        final Property oldProperty = super.property(key);
+        final Property<V> p = updateSpecificProperty(key, value);
+        TinkerHelper.autoUpdateIndex(this, key, value, oldProperty.isPresent() ? oldProperty.value() : null);
+        return p;
     }
 
     protected abstract <V> Property<V> updateSpecificProperty(String key, V value);

--- a/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerGraph.java
+++ b/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerGraph.java
@@ -184,8 +184,9 @@ public final class TinkerGraph implements Graph {
 
         if (specializedVertexFactoryByLabel.containsKey(label)) {
             SpecializedElementFactory.ForVertex factory = specializedVertexFactoryByLabel.get(label);
-            SpecializedTinkerVertex vertex = factory.createVertex(idValue, this, ElementHelper.asMap(keyValues));
+            SpecializedTinkerVertex vertex = factory.createVertex(idValue, this);
             this.vertices.put(idValue, vertex);
+            ElementHelper.attachProperties(vertex, VertexProperty.Cardinality.list, keyValues);
             return vertex;
         } else { // vertex label not registered for a specialized factory, treating as generic vertex
             if (this.usesSpecializedElements) {

--- a/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/specialized/gratefuldead/Artist.java
+++ b/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/specialized/gratefuldead/Artist.java
@@ -30,30 +30,28 @@ import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils;
 import java.util.*;
 
 public class Artist extends SpecializedTinkerVertex<String> {
-    public static String label = "artist";
+    public static final String label = "artist";
 
-    public static String NAME = "name";
-    public static Set<String> SPECIFIC_KEYS = new HashSet<>(Arrays.asList(NAME));
+    public static final String NAME = "name";
+    public static final Set<String> SPECIFIC_KEYS = new HashSet<>(Arrays.asList(NAME));
 
     // properties
     private String name;
 
     // edges
-    public static String[] ALL_EDGES = new String[] {WrittenBy.label, SungBy.label};
+    public static final String[] ALL_EDGES = new String[] {WrittenBy.label, SungBy.label};
     private Set<SungBy> sungByIn;
     private Set<WrittenBy> writtenByIn;
 
-    public Artist(String id, TinkerGraph graph, String name) {
+    public Artist(String id, TinkerGraph graph) {
         super(id, Artist.label, graph, SPECIFIC_KEYS);
-
-        this.name = name;
     }
 
     /* note: usage of `==` (pointer comparison) over `.equals` (String content comparison) is intentional for performance - use the statically defined strings */
     @Override
     protected <V> Iterator<VertexProperty<V>> specificProperties(String key) {
         final VertexProperty<V> ret;
-        if (key == NAME && name != null) {
+        if (NAME.equals(key) && name != null) {
             ret = new TinkerVertexProperty(this, key, name);
         } else {
             ret = VertexProperty.empty();
@@ -64,7 +62,7 @@ public class Artist extends SpecializedTinkerVertex<String> {
     @Override
     protected <V> VertexProperty<V> updateSpecificProperty(
       VertexProperty.Cardinality cardinality, String key, V value) {
-        if (key == NAME) {
+        if (NAME.equals(key)) {
             this.name = (String) value;
         } else {
             throw new RuntimeException("property with key=" + key + " not (yet) supported by " + this.getClass().getName());
@@ -152,9 +150,8 @@ public class Artist extends SpecializedTinkerVertex<String> {
         }
 
         @Override
-        public Artist createVertex(String id, TinkerGraph graph, Map<String, Object> keyValueMap) {
-            String name = (String) keyValueMap.get("name");
-            return new Artist(id, graph, name);
+        public Artist createVertex(String id, TinkerGraph graph) {
+            return new Artist(id, graph);
         }
     };
 

--- a/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/specialized/gratefuldead/FollowedBy.java
+++ b/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/specialized/gratefuldead/FollowedBy.java
@@ -27,22 +27,21 @@ import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerProperty;
 import java.util.*;
 
 public class FollowedBy extends SpecializedTinkerEdge<String> {
-    public static String label = "followedBy";
+    public static final String label = "followedBy";
 
-    public static String WEIGHT = "weight";
-    public static Set<String> SPECIFIC_KEYS = new HashSet<>(Arrays.asList(WEIGHT));
+    public static final String WEIGHT = "weight";
+    public static final Set<String> SPECIFIC_KEYS = new HashSet<>(Arrays.asList(WEIGHT));
 
     private Integer weight;
 
-    public FollowedBy(String id, Vertex outVertex, Vertex inVertex, Integer weight) {
+    public FollowedBy(String id, Vertex outVertex, Vertex inVertex) {
         super(id, outVertex, label, inVertex, SPECIFIC_KEYS);
-        this.weight = weight;
     }
 
     @Override
     protected <V> Property<V> specificProperty(String key) {
-        // note: usage of `==` (pointer comparison) over `.equals` (String content comparison) is intentional for performance - use the statically defined strings
-        if (key == WEIGHT && weight != null) {
+        // note: use the statically defined strings to take advantage of `==` (pointer comparison) over `.equals` (String content comparison) for performance 
+        if (WEIGHT.equals(key) && weight != null) {
             return new TinkerProperty(this, key, weight);
         } else {
             return Property.empty();
@@ -51,7 +50,7 @@ public class FollowedBy extends SpecializedTinkerEdge<String> {
 
     @Override
     protected <V> Property<V> updateSpecificProperty(String key, V value) {
-        if (key == WEIGHT) {
+        if (WEIGHT.equals(key)) {
             this.weight = (Integer) value;
         } else {
             throw new RuntimeException("property with key=" + key + " not (yet) supported by " + this.getClass().getName());
@@ -66,9 +65,8 @@ public class FollowedBy extends SpecializedTinkerEdge<String> {
         }
 
         @Override
-        public FollowedBy createEdge(String id, Vertex outVertex, Vertex inVertex, Map<String, Object> keyValueMap) {
-            Integer weight = (Integer) keyValueMap.get("weight");
-            return new FollowedBy(id, outVertex, inVertex, weight);
+        public FollowedBy createEdge(String id, Vertex outVertex, Vertex inVertex) {
+            return new FollowedBy(id, outVertex, inVertex);
         }
     };
 }

--- a/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/specialized/gratefuldead/Song.java
+++ b/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/specialized/gratefuldead/Song.java
@@ -30,12 +30,12 @@ import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils;
 import java.util.*;
 
 public class Song extends SpecializedTinkerVertex<String> {
-    public static String label = "song";
+    public static final String label = "song";
 
-    public static String NAME = "name";
-    public static String SONG_TYPE = "songType";
-    public static String PERFORMANCES = "performances";
-    public static Set<String> SPECIFIC_KEYS = new HashSet<>(Arrays.asList(NAME, SONG_TYPE, PERFORMANCES));
+    public static final String NAME = "name";
+    public static final String SONG_TYPE = "songType";
+    public static final String PERFORMANCES = "performances";
+    public static final Set<String> SPECIFIC_KEYS = new HashSet<>(Arrays.asList(NAME, SONG_TYPE, PERFORMANCES));
 
     // properties
     private String name;
@@ -43,18 +43,14 @@ public class Song extends SpecializedTinkerVertex<String> {
     private Integer performances;
 
     // edges
-    public static String[] ALL_EDGES = new String[] {FollowedBy.label, WrittenBy.label, SungBy.label};
+    public static final String[] ALL_EDGES = new String[] {FollowedBy.label, WrittenBy.label, SungBy.label};
     private Set<FollowedBy> followedByOut;
     private Set<FollowedBy> followedByIn;
     private Set<WrittenBy> writtenByOut;
     private Set<SungBy> sungByOut;
 
-    public Song(String id, TinkerGraph graph, String name, String songType, Integer performances) {
+    public Song(String id, TinkerGraph graph) {
         super(id, Song.label, graph, SPECIFIC_KEYS);
-
-        this.name = name;
-        this.songType = songType;
-        this.performances = performances;
     }
 
     /* note: usage of `==` (pointer comparison) over `.equals` (String content comparison) is intentional for performance - use the statically defined strings */
@@ -76,11 +72,11 @@ public class Song extends SpecializedTinkerVertex<String> {
     @Override
     protected <V> VertexProperty<V> updateSpecificProperty(
       VertexProperty.Cardinality cardinality, String key, V value) {
-        if (key == NAME) {
+        if (NAME.equals(key)) {
             this.name = (String) value;
-        } else if (key == SONG_TYPE) {
+        } else if (SONG_TYPE.equals(key)) {
             this.songType = (String) value;
-        } else if (key == PERFORMANCES) {
+        } else if (PERFORMANCES.equals(key)) {
             this.performances = (Integer) value;
         } else {
             throw new RuntimeException("property with key=" + key + " not (yet) supported by " + this.getClass().getName());
@@ -205,11 +201,8 @@ public class Song extends SpecializedTinkerVertex<String> {
         }
 
         @Override
-        public Song createVertex(String id, TinkerGraph graph, Map<String, Object> keyValueMap) {
-            String name = (String) keyValueMap.get("name");
-            String songType = (String) keyValueMap.get("songType");
-            Integer performances = (Integer) keyValueMap.get("performances");
-            return new Song(id, graph, name, songType, performances);
+        public Song createVertex(String id, TinkerGraph graph) {
+            return new Song(id, graph);
         }
     };
 }

--- a/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/specialized/gratefuldead/SungBy.java
+++ b/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/specialized/gratefuldead/SungBy.java
@@ -26,9 +26,9 @@ import org.apache.tinkerpop.gremlin.tinkergraph.structure.SpecializedTinkerEdge;
 import java.util.*;
 
 public class SungBy extends SpecializedTinkerEdge<String> {
-    public static String label = "sungBy";
+    public static final String label = "sungBy";
 
-    public static Set<String> SPECIFIC_KEYS = new HashSet<>(Arrays.asList());
+    public static final Set<String> SPECIFIC_KEYS = new HashSet<>(Arrays.asList());
 
     public SungBy(String id, Vertex outVertex, Vertex inVertex) {
         super(id, outVertex, label, inVertex, SPECIFIC_KEYS);
@@ -51,7 +51,7 @@ public class SungBy extends SpecializedTinkerEdge<String> {
         }
 
         @Override
-        public SungBy createEdge(String id, Vertex outVertex, Vertex inVertex, Map<String, Object> keyValueMap) {
+        public SungBy createEdge(String id, Vertex outVertex, Vertex inVertex) {
             return new SungBy(id, outVertex, inVertex);
         }
     };

--- a/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/specialized/gratefuldead/WrittenBy.java
+++ b/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/specialized/gratefuldead/WrittenBy.java
@@ -26,9 +26,9 @@ import org.apache.tinkerpop.gremlin.tinkergraph.structure.SpecializedTinkerEdge;
 import java.util.*;
 
 public class WrittenBy extends SpecializedTinkerEdge<String> {
-    public static String label = "writtenBy";
+    public static final String label = "writtenBy";
 
-    public static Set<String> SPECIFIC_KEYS = new HashSet<>(Arrays.asList());
+    public static final Set<String> SPECIFIC_KEYS = new HashSet<>(Arrays.asList());
 
     public WrittenBy(String id, Vertex outVertex, Vertex inVertex) {
         super(id, outVertex, label, inVertex, SPECIFIC_KEYS);
@@ -51,7 +51,7 @@ public class WrittenBy extends SpecializedTinkerEdge<String> {
         }
 
         @Override
-        public WrittenBy createEdge(String id, Vertex outVertex, Vertex inVertex, Map<String, Object> keyValueMap) {
+        public WrittenBy createEdge(String id, Vertex outVertex, Vertex inVertex) {
             return new WrittenBy(id, outVertex, inVertex);
         }
     };


### PR DESCRIPTION
Fixes #4 

To take advantage of TinkerGraph's TinkerIndex on Vertex, Edge creation, creation must rely on the `property` mutator. This makes class construction key,value params futile.

This also fixes the case where a property is updated.

Breaking change. 
* SpecializedElementFactory drops `keyValueMap`

Other:
* Use `equals()` for key comparison for where we don't have control over the input thus can not take advantage of statically defined strings (e.g. `loadGraphMl()`). Should have minimal impact on performance since first thing `equals()` does is `==` comparison.
* Added some TinkerVertex, TinkerEdge property validations
* Added `final` to things that should not change in test. People may use this as reference and this is good practice.