### PR TITLE
optimize traversals when using `hasLabel` step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,8 @@ env:
   - secure: "EHFR32uQ+IdZDHo3vb2ha+ow0c7UH1EYWofT7PUIZ8HRcQxXm/fFrmm00Z1tZaC8bTcI//Lrdd6k7lBnNGpb80y+LfxR4ZMD06qoqzTKULYxWEInNsjLSk89T/SUcwnfqJIRgi+LT/vx7OYEKGsDL0mLG8fns47ScGAJO+Kpk2pcAgHn2z1N5o1leD0ZhvmoD3i8C9Rd/N0MgZ0Em/+ERHN2Gioz9s/g7hRMbdHPwhGcxUK0F9z3xGuSxswVPsMAMakJJ0gKHm6cD6mtkyq501+3G8JufCqZ4xR+H60ePOMWPmKDD4ome4v5/8nnm/AwMCQKVLCJuYAs1eZK3fvgqt8WIw8AF2RZbVA9H2bS+n/4xE5yWiEYnNkm5kiTmduzW/F+jjIidIRp8UGSyAJkjWvIZc+9H/hFcH1xurvGRKXQbtWtzV/55bfonvdjYGKNftJsVtisYaFI95qdjP1+xoq9PbIy/SDjx5MD6khOYn6gqllM6BFWNobvzQcwyLr9uMsyzINR3Cq+Ny1PYY17aXiyagMN4EjznadbRxToqnY+bY5M8KLtnAN6oXUKzeLia9uZq/GixzTPL6FfuJkztOMLiIdlP6rO0wx2bi3fl6TnVZiuj7VhdCqnYdjr4ciAz2ZnR45k+s2ZmAOwLX8tYyjK+w56uE/ViJnN8zVyJzU="
 
 install: mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
-script: mvn -Dtest=SpecializedElementsTest test
+
+script: mvn -Dtest=SpecializedElementsTest,SpecializedElementsWithOnDiskTest test
 # TODO reenable standard tests
 #script: mvn test -B
 

--- a/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/process/traversal/step/sideEffect/TinkerGraphStep.java
+++ b/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/process/traversal/step/sideEffect/TinkerGraphStep.java
@@ -58,11 +58,14 @@ public final class TinkerGraphStep<S, E extends Element> extends GraphStep<S, E>
     private Iterator<? extends Edge> edges() {
         final TinkerGraph graph = (TinkerGraph) this.getTraversal().getGraph().get();
         final HasContainer indexedContainer = getIndexKey(Edge.class);
+        final Optional<HasContainer> hasLabelContainer = findHasLabelStep();
         // ids are present, filter on them first
         if (null == this.ids)
             return Collections.emptyIterator();
         else if (this.ids.length > 0)
             return this.iteratorList(graph.edges(this.ids));
+        else if (graph.ondiskOverflowEnabled && hasLabelContainer.isPresent())
+            return graph.edgesByLabel((P<String>) hasLabelContainer.get().getPredicate());
         else
             return null == indexedContainer ?
                     this.iteratorList(graph.edges()) :
@@ -80,9 +83,9 @@ public final class TinkerGraphStep<S, E extends Element> extends GraphStep<S, E>
             return Collections.emptyIterator();
         else if (this.ids.length > 0)
             return this.iteratorList(graph.vertices(this.ids));
-        else if (graph.ondiskOverflowEnabled && hasLabelContainer.isPresent()) {
+        else if (graph.ondiskOverflowEnabled && hasLabelContainer.isPresent())
             return graph.verticesByLabel((P<String>) hasLabelContainer.get().getPredicate());
-        } else
+        else
             return null == indexedContainer ?
                     this.iteratorList(graph.vertices()) :
                     IteratorUtils.filter(TinkerHelper.queryVertexIndex(graph, indexedContainer.getKey(), indexedContainer.getPredicate().getValue()).iterator(),

--- a/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/process/traversal/step/sideEffect/TinkerGraphStep.java
+++ b/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/process/traversal/step/sideEffect/TinkerGraphStep.java
@@ -81,8 +81,7 @@ public final class TinkerGraphStep<S, E extends Element> extends GraphStep<S, E>
         else if (this.ids.length > 0)
             return this.iteratorList(graph.vertices(this.ids));
         else if (graph.ondiskOverflowEnabled && hasLabelContainer.isPresent()) {
-            String label = (String) hasLabelContainer.get().getPredicate().getValue();
-            return graph.verticesByLabel(label);
+            return graph.verticesByLabel((P<String>) hasLabelContainer.get().getPredicate());
         } else
             return null == indexedContainer ?
                     this.iteratorList(graph.vertices()) :

--- a/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/process/traversal/step/sideEffect/TinkerGraphStep.java
+++ b/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/process/traversal/step/sideEffect/TinkerGraphStep.java
@@ -90,10 +90,12 @@ public final class TinkerGraphStep<S, E extends Element> extends GraphStep<S, E>
                             vertex -> HasContainer.testAll(vertex, this.hasContainers));
     }
 
+    // only optimize if hasLabel is the _only_ hasContainer, since that's the simplest case
+    // TODO implement other cases as well, e.g. for `g.V.hasLabel(lbl).has(k,v)`
     private Optional<HasContainer> findHasLabelStep() {
-        for (HasContainer hasContainer : hasContainers) {
-            if (T.label.getAccessor().equals(hasContainer.getKey())) {
-                return Optional.of(hasContainer);
+        if (hasContainers.size() == 1) {
+            if (T.label.getAccessor().equals(hasContainers.get(0).getKey())) {
+                return Optional.of(hasContainers.get(0));
             }
         }
         return Optional.empty();

--- a/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/process/traversal/step/sideEffect/TinkerGraphStep.java
+++ b/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/process/traversal/step/sideEffect/TinkerGraphStep.java
@@ -80,7 +80,7 @@ public final class TinkerGraphStep<S, E extends Element> extends GraphStep<S, E>
             return Collections.emptyIterator();
         else if (this.ids.length > 0)
             return this.iteratorList(graph.vertices(this.ids));
-        else if (hasLabelContainer.isPresent()) {
+        else if (graph.ondiskOverflowEnabled && hasLabelContainer.isPresent()) {
             String label = (String) hasLabelContainer.get().getPredicate().getValue();
             return graph.verticesByLabel(label);
         } else

--- a/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/process/traversal/step/sideEffect/TinkerGraphStep.java
+++ b/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/process/traversal/step/sideEffect/TinkerGraphStep.java
@@ -26,18 +26,14 @@ import org.apache.tinkerpop.gremlin.process.traversal.step.util.HasContainer;
 import org.apache.tinkerpop.gremlin.process.traversal.util.AndP;
 import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Element;
+import org.apache.tinkerpop.gremlin.structure.T;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
 import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerGraph;
 import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerHelper;
 import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 /**
@@ -78,16 +74,29 @@ public final class TinkerGraphStep<S, E extends Element> extends GraphStep<S, E>
     private Iterator<? extends Vertex> vertices() {
         final TinkerGraph graph = (TinkerGraph) this.getTraversal().getGraph().get();
         final HasContainer indexedContainer = getIndexKey(Vertex.class);
+        final Optional<HasContainer> hasLabelContainer = findHasLabelStep();
         // ids are present, filter on them first
         if (null == this.ids)
             return Collections.emptyIterator();
         else if (this.ids.length > 0)
             return this.iteratorList(graph.vertices(this.ids));
-        else
+        else if (hasLabelContainer.isPresent()) {
+            String label = (String) hasLabelContainer.get().getPredicate().getValue();
+            return graph.verticesByLabel(label);
+        } else
             return null == indexedContainer ?
                     this.iteratorList(graph.vertices()) :
                     IteratorUtils.filter(TinkerHelper.queryVertexIndex(graph, indexedContainer.getKey(), indexedContainer.getPredicate().getValue()).iterator(),
                             vertex -> HasContainer.testAll(vertex, this.hasContainers));
+    }
+
+    private Optional<HasContainer> findHasLabelStep() {
+        for (HasContainer hasContainer : hasContainers) {
+            if (T.label.getAccessor().equals(hasContainer.getKey())) {
+                return Optional.of(hasContainer);
+            }
+        }
+        return Optional.empty();
     }
 
     private HasContainer getIndexKey(final Class<? extends Element> indexedClass) {
@@ -96,7 +105,6 @@ public final class TinkerGraphStep<S, E extends Element> extends GraphStep<S, E>
         final Iterator<HasContainer> itty = IteratorUtils.filter(hasContainers.iterator(),
                 c -> c.getPredicate().getBiPredicate() == Compare.eq && indexedKeys.contains(c.getKey()));
         return itty.hasNext() ? itty.next() : null;
-
     }
 
     @Override

--- a/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/storage/org/apache/tinkerpop/gremlin/util/iterator/ArrayBackedTLongIterator.java
+++ b/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/storage/org/apache/tinkerpop/gremlin/util/iterator/ArrayBackedTLongIterator.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.tinkergraph.storage.org.apache.tinkerpop.gremlin.util.iterator;
+
+import gnu.trove.iterator.TLongIterator;
+import org.apache.commons.lang3.NotImplementedException;
+import org.apache.tinkerpop.gremlin.process.traversal.util.FastNoSuchElementException;
+
+import java.util.List;
+
+/**
+ * A TLongIterator backed by an Array.
+ * Technically this is nonsense - why would you use an Iterator it holds a reference to all the data?
+ * Since java arrays don't implement `Iterator`, I didn't find a better way.
+ * */
+public class ArrayBackedTLongIterator implements TLongIterator {
+
+  private final long[] array;
+  private int cursor = 0;
+
+  public ArrayBackedTLongIterator(long[] array) {
+    this.array = array;
+  }
+
+  /* for better performance, use the `long[]` alternative, since it doesn't require boxing/unboxing */
+  public ArrayBackedTLongIterator(Long[] array) {
+    this.array = new long[array.length];
+    for (int i = 0; i < array.length; i++) {
+      this.array[i] = array[i];
+    }
+  }
+
+  @Override
+  public boolean hasNext() {
+    return array.length > cursor;
+  }
+
+  @Override
+  public long next() {
+    return array[cursor++];
+  }
+
+  @Override
+  public void remove() {
+    throw new NotImplementedException("");
+  }
+
+}

--- a/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/storage/org/apache/tinkerpop/gremlin/util/iterator/TLongMultiIterator.java
+++ b/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/storage/org/apache/tinkerpop/gremlin/util/iterator/TLongMultiIterator.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.tinkergraph.storage.org.apache.tinkerpop.gremlin.util.iterator;
+
+import gnu.trove.iterator.TLongIterator;
+import org.apache.commons.lang3.NotImplementedException;
+import org.apache.tinkerpop.gremlin.process.traversal.util.FastNoSuchElementException;
+
+import java.util.List;
+
+/**
+ * Analogous to `MultiIterator`, but specific for TLongIterators
+ * This wouldn't be necessary if only java/trove iterators had `flatMap` :(
+ * */
+public class TLongMultiIterator implements TLongIterator {
+
+  private final List<TLongIterator> iterators;
+  private int current = 0;
+
+  public TLongMultiIterator(List<TLongIterator> iterators) {
+    this.iterators = iterators;
+  }
+
+  @Override
+  public boolean hasNext() {
+    if (this.current >= iterators.size())
+      return false;
+
+    TLongIterator currentIterator = iterators.get(this.current);
+
+    while (true) {
+      if (currentIterator.hasNext()) {
+        return true;
+      } else {
+        this.current++;
+        if (this.current >= iterators.size())
+          break;
+        currentIterator = iterators.get(this.current);
+      }
+    }
+    return false;
+  }
+
+  @Override
+  public long next() {
+    if (iterators.isEmpty()) throw FastNoSuchElementException.instance();
+
+    TLongIterator currentIterator = iterators.get(this.current);
+    while (true) {
+      if (currentIterator.hasNext()) {
+        return currentIterator.next();
+      } else {
+        this.current++;
+        if (this.current >= iterators.size())
+          break;
+        currentIterator = iterators.get(current);
+      }
+    }
+    throw FastNoSuchElementException.instance();
+  }
+
+  @Override
+  public void remove() {
+    throw new NotImplementedException("");
+  }
+}

--- a/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/SpecializedTinkerEdge.java
+++ b/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/SpecializedTinkerEdge.java
@@ -112,7 +112,7 @@ public abstract class SpecializedTinkerEdge extends TinkerEdge {
         TinkerHelper.removeElementIndex(this);
         graph.edges.remove(id);
         if (graph.ondiskOverflowEnabled) {
-            graph.edgeIds.remove(id);
+            graph.edgeIdsByLabel.get(label()).remove(id);
             graph.onDiskEdgeOverflow.remove(id);
             graph.edgeCache.remove(id);
         }

--- a/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/SpecializedTinkerVertex.java
+++ b/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/SpecializedTinkerVertex.java
@@ -18,6 +18,7 @@
  */
 package org.apache.tinkerpop.gremlin.tinkergraph.structure;
 
+import gnu.trove.set.TLongSet;
 import org.apache.tinkerpop.gremlin.structure.*;
 import org.apache.tinkerpop.gremlin.structure.util.ElementHelper;
 import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils;
@@ -122,10 +123,8 @@ public abstract class SpecializedTinkerVertex extends TinkerVertex {
 
             Long idValue = (Long) graph.edgeIdManager.convert(ElementHelper.getIdValue(keyValues).orElse(null));
             if (null != idValue) {
-                if ((graph.ondiskOverflowEnabled && graph.edgeIds.contains(idValue)) ||
-                  (!graph.ondiskOverflowEnabled && graph.edges.containsKey(idValue))) {
+                if (edgeIdAlreadyExists(idValue))
                     throw Graph.Exceptions.edgeWithIdAlreadyExists(idValue);
-                }
             } else {
                 idValue = (Long) graph.edgeIdManager.getNextId(graph);
             }
@@ -137,7 +136,7 @@ public abstract class SpecializedTinkerVertex extends TinkerVertex {
             SpecializedTinkerEdge edge = factory.createEdge(idValue, graph, (long) outVertex.id, (long) inVertex.id);
             ElementHelper.attachProperties(edge, keyValues);
             if (graph.ondiskOverflowEnabled) {
-                graph.edgeIds.add(idValue);
+                graph.getElementIdsByLabel(graph.edgeIdsByLabel, label).add(idValue);
                 graph.edgeCache.put(idValue, edge);
             } else {
                 graph.edges.put(idValue, edge);
@@ -156,6 +155,19 @@ public abstract class SpecializedTinkerVertex extends TinkerVertex {
                         + ". Mixing specialized and generic elements is not (yet) supported");
             }
             return super.addEdge(label, vertex, keyValues);
+        }
+    }
+
+    private boolean edgeIdAlreadyExists(Long idValue) {
+        if (!graph.ondiskOverflowEnabled) {
+            return graph.edges.containsKey(idValue);
+        } else {
+            for (TLongSet ids : graph.edgeIdsByLabel.values()) {
+                if (ids.contains(idValue.longValue())) {
+                    return true;
+                }
+            }
+            return false;
         }
     }
 
@@ -213,6 +225,7 @@ public abstract class SpecializedTinkerVertex extends TinkerVertex {
             this.graph.onDiskVertexOverflow.remove(id);
         }
         this.graph.vertices.remove(id);
+        edges(Direction.BOTH).forEachRemaining(Element::remove);
 
         this.modifiedSinceLastSerialization = true;
         releaseModificationLock();

--- a/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/SpecializedTinkerVertex.java
+++ b/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/SpecializedTinkerVertex.java
@@ -209,7 +209,7 @@ public abstract class SpecializedTinkerVertex extends TinkerVertex {
 
         if (graph.ondiskOverflowEnabled) {
             this.graph.vertexCache.remove(id);
-            this.graph.vertexIds.remove(id);
+            this.graph.vertexIdsByLabel.get(label()).remove(id);
             this.graph.onDiskVertexOverflow.remove(id);
         }
         this.graph.vertices.remove(id);

--- a/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerGraph.java
+++ b/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/TinkerGraph.java
@@ -47,6 +47,7 @@ import org.apache.tinkerpop.gremlin.tinkergraph.process.traversal.strategy.optim
 import org.apache.tinkerpop.gremlin.tinkergraph.storage.EdgeSerializer;
 import org.apache.tinkerpop.gremlin.tinkergraph.storage.Serializer;
 import org.apache.tinkerpop.gremlin.tinkergraph.storage.VertexSerializer;
+import org.apache.tinkerpop.gremlin.tinkergraph.storage.org.apache.tinkerpop.gremlin.util.iterator.ArrayBackedTLongIterator;
 import org.apache.tinkerpop.gremlin.tinkergraph.storage.org.apache.tinkerpop.gremlin.util.iterator.TLongMultiIterator;
 import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils;
 import org.ehcache.Cache;
@@ -475,25 +476,7 @@ public final class TinkerGraph implements Graph {
                 }
                 idsIterator = new TLongMultiIterator(iterators);
             } else {
-                // TODO extract for reuse and conciseness
-                idsIterator = new TLongIterator() {
-                    private int cursor = 0;
-
-                    @Override
-                    public boolean hasNext() {
-                        return ids.length > cursor;
-                    }
-
-                    @Override
-                    public long next() {
-                        return (Long) ids[cursor++];
-                    }
-
-                    @Override
-                    public void remove() {
-                        throw new NotImplementedException("");
-                    }
-                };
+                idsIterator = new ArrayBackedTLongIterator((Long[]) ids);
             }
           return createElementIteratorForCached(vertexCache, onDiskVertexOverflow, vertexSerializer, idsIterator);
         } else {

--- a/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/SpecializedElementsTest.java
+++ b/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/SpecializedElementsTest.java
@@ -102,9 +102,15 @@ public class SpecializedElementsTest {
     public void optimizationStrategyAffectedSteps() throws IOException {
         TinkerGraph graph = newGratefulDeadGraphWithSpecializedElementsWithData();
 
-        assertEquals(584, graph.traversal().V().hasLabel(Song.label).toList().size());
-        assertEquals(142, graph.traversal().V().has(Song.PERFORMANCES, 1).toList().size());
-        assertEquals(142, graph.traversal().V().hasLabel(Song.label).has(Song.PERFORMANCES, 1).toList().size());
+      assertEquals(584, graph.traversal().V().hasLabel(Song.label).toList().size());
+      assertEquals(142, graph.traversal().V().has(Song.PERFORMANCES, 1).toList().size());
+      assertEquals(142, graph.traversal().V().has(Song.PERFORMANCES, 1).hasLabel(Song.label).toList().size());
+      assertEquals(142, graph.traversal().V().hasLabel(Song.label).has(Song.PERFORMANCES, 1).toList().size());
+      assertEquals(7047, graph.traversal().V().out().hasLabel(Song.label).toList().size());
+      assertEquals(1, graph.traversal().V(800).hasLabel(Song.label).toList().size());
+      assertEquals(5, graph.traversal().V(1).out().hasLabel(Song.label).toList().size());
+      assertEquals(0, graph.traversal().V().hasLabel(Song.label).hasLabel(Artist.label).toList().size());
+      assertEquals(808, graph.traversal().V().hasLabel(Song.label, Artist.label).toList().size());
 
         graph.close();
     }

--- a/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/SpecializedElementsTest.java
+++ b/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/SpecializedElementsTest.java
@@ -93,6 +93,17 @@ public class SpecializedElementsTest {
         List<Vertex> songBoth = __(song).both(WrittenBy.label).toList();
         assertEquals(1, songBoth.size());
         assertEquals(garcia, songBoth.get(0));
+
+        graph.close();
+    }
+
+    @Test
+    /* ensure these are identical for both ondisk overflow enabled/disabled */
+    public void optimizationStrategyAffectedSteps() throws IOException {
+        TinkerGraph graph = newGratefulDeadGraphWithSpecializedElementsWithData();
+
+        assertEquals(584, graph.traversal().V().hasLabel(Song.label).toList().size());
+
         graph.close();
     }
 

--- a/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/SpecializedElementsTest.java
+++ b/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/SpecializedElementsTest.java
@@ -102,17 +102,28 @@ public class SpecializedElementsTest {
     public void optimizationStrategyAffectedSteps() throws IOException {
         TinkerGraph graph = newGratefulDeadGraphWithSpecializedElementsWithData();
 
+        // using `g.V().hasLabel(lbl)` optimization
         assertEquals(584, graph.traversal().V().hasLabel(Song.label).toList().size());
         assertEquals(142, graph.traversal().V().has(Song.PERFORMANCES, 1).toList().size());
         assertEquals(142, graph.traversal().V().has(Song.PERFORMANCES, 1).hasLabel(Song.label).toList().size());
         assertEquals(142, graph.traversal().V().hasLabel(Song.label).has(Song.PERFORMANCES, 1).toList().size());
         assertEquals(7047, graph.traversal().V().out().hasLabel(Song.label).toList().size());
-        assertEquals(1, graph.traversal().V(800).hasLabel(Song.label).toList().size());
-        assertEquals(5, graph.traversal().V(1).out().hasLabel(Song.label).toList().size());
+        assertEquals(1, graph.traversal().V(800l).hasLabel(Song.label).toList().size());
+        assertEquals(5, graph.traversal().V(1l).out().hasLabel(Song.label).toList().size());
         assertEquals(0, graph.traversal().V().hasLabel(Song.label).hasLabel(Artist.label).toList().size());
         assertEquals(808, graph.traversal().V().hasLabel(Song.label, Artist.label).toList().size());
         assertEquals(501, graph.traversal().V().outE().hasLabel(WrittenBy.label).toList().size());
         assertEquals(501, graph.traversal().V().hasLabel(Song.label).outE().hasLabel(WrittenBy.label).toList().size());
+
+        // using `g.E().hasLabel(lbl)` optimization
+        assertEquals(8049, graph.traversal().E().toList().size());
+        assertEquals(7047, graph.traversal().E().hasLabel(FollowedBy.label).toList().size());
+        assertEquals(3564, graph.traversal().E().has(FollowedBy.WEIGHT, 1).toList().size());
+        assertEquals(3564, graph.traversal().E().hasLabel(FollowedBy.label).has(FollowedBy.WEIGHT, 1).toList().size());
+        assertEquals(3564, graph.traversal().E().has(FollowedBy.WEIGHT, 1).hasLabel(FollowedBy.label).toList().size());
+        assertEquals(7047, graph.traversal().E().hasLabel(FollowedBy.label).outV().hasLabel(Song.label).toList().size());
+        assertEquals(1, graph.traversal().E(0l).hasLabel(FollowedBy.label).toList().size());
+        assertEquals(7548, graph.traversal().E().hasLabel(FollowedBy.label, SungBy.label).toList().size());
 
         graph.close();
     }
@@ -214,7 +225,7 @@ public class SpecializedElementsTest {
         assertTrue("avg time with index should be (significantly) less than without index",
             avgTimeWithIndex < avgTimeWithoutIndex);
     }
-    
+
     @Test
     public void shouldUseIndicesCreatedBeforeLoadingData() throws IOException {
         int loops = 100;
@@ -342,7 +353,7 @@ public class SpecializedElementsTest {
             Arrays.asList(FollowedBy.factory, SungBy.factory, WrittenBy.factory)
         );
     }
-    
+
     private TinkerGraph newGratefulDeadGraphWithSpecializedElementsWithData() throws IOException {
         TinkerGraph graph = newGratefulDeadGraphWithSpecializedElements();
         loadGraphMl(graph);

--- a/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/SpecializedElementsTest.java
+++ b/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/SpecializedElementsTest.java
@@ -102,15 +102,17 @@ public class SpecializedElementsTest {
     public void optimizationStrategyAffectedSteps() throws IOException {
         TinkerGraph graph = newGratefulDeadGraphWithSpecializedElementsWithData();
 
-      assertEquals(584, graph.traversal().V().hasLabel(Song.label).toList().size());
-      assertEquals(142, graph.traversal().V().has(Song.PERFORMANCES, 1).toList().size());
-      assertEquals(142, graph.traversal().V().has(Song.PERFORMANCES, 1).hasLabel(Song.label).toList().size());
-      assertEquals(142, graph.traversal().V().hasLabel(Song.label).has(Song.PERFORMANCES, 1).toList().size());
-      assertEquals(7047, graph.traversal().V().out().hasLabel(Song.label).toList().size());
-      assertEquals(1, graph.traversal().V(800).hasLabel(Song.label).toList().size());
-      assertEquals(5, graph.traversal().V(1).out().hasLabel(Song.label).toList().size());
-      assertEquals(0, graph.traversal().V().hasLabel(Song.label).hasLabel(Artist.label).toList().size());
-      assertEquals(808, graph.traversal().V().hasLabel(Song.label, Artist.label).toList().size());
+        assertEquals(584, graph.traversal().V().hasLabel(Song.label).toList().size());
+        assertEquals(142, graph.traversal().V().has(Song.PERFORMANCES, 1).toList().size());
+        assertEquals(142, graph.traversal().V().has(Song.PERFORMANCES, 1).hasLabel(Song.label).toList().size());
+        assertEquals(142, graph.traversal().V().hasLabel(Song.label).has(Song.PERFORMANCES, 1).toList().size());
+        assertEquals(7047, graph.traversal().V().out().hasLabel(Song.label).toList().size());
+        assertEquals(1, graph.traversal().V(800).hasLabel(Song.label).toList().size());
+        assertEquals(5, graph.traversal().V(1).out().hasLabel(Song.label).toList().size());
+        assertEquals(0, graph.traversal().V().hasLabel(Song.label).hasLabel(Artist.label).toList().size());
+        assertEquals(808, graph.traversal().V().hasLabel(Song.label, Artist.label).toList().size());
+        assertEquals(501, graph.traversal().V().outE().hasLabel(WrittenBy.label).toList().size());
+        assertEquals(501, graph.traversal().V().hasLabel(Song.label).outE().hasLabel(WrittenBy.label).toList().size());
 
         graph.close();
     }

--- a/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/SpecializedElementsTest.java
+++ b/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/SpecializedElementsTest.java
@@ -103,6 +103,8 @@ public class SpecializedElementsTest {
         TinkerGraph graph = newGratefulDeadGraphWithSpecializedElementsWithData();
 
         assertEquals(584, graph.traversal().V().hasLabel(Song.label).toList().size());
+        assertEquals(142, graph.traversal().V().has(Song.PERFORMANCES, 1).toList().size());
+        assertEquals(142, graph.traversal().V().hasLabel(Song.label).has(Song.PERFORMANCES, 1).toList().size());
 
         graph.close();
     }

--- a/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/SpecializedElementsWithOnDiskTest.java
+++ b/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/SpecializedElementsWithOnDiskTest.java
@@ -64,6 +64,8 @@ public class SpecializedElementsWithOnDiskTest {
         TinkerGraph graph = newGratefulDeadGraphWithSpecializedElementsWithData();
 
         assertEquals(584, graph.traversal().V().hasLabel(Song.label).toList().size());
+        assertEquals(142, graph.traversal().V().has(Song.PERFORMANCES, 1).toList().size());
+        assertEquals(142, graph.traversal().V().hasLabel(Song.label).has(Song.PERFORMANCES, 1).toList().size());
 
         graph.close();
     }

--- a/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/SpecializedElementsWithOnDiskTest.java
+++ b/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/SpecializedElementsWithOnDiskTest.java
@@ -256,7 +256,8 @@ public class SpecializedElementsWithOnDiskTest {
             avgTimeWithIndex < avgTimeWithoutIndex);
     }
     
-    @Test
+    // @Test
+    // only run manually since the timings vary depending on the environment
     public void shouldUseIndicesCreatedBeforeLoadingData() throws IOException {
         int loops = 100;
         Double avgTimeWithIndex = null;

--- a/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/SpecializedElementsWithOnDiskTest.java
+++ b/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/SpecializedElementsWithOnDiskTest.java
@@ -65,7 +65,13 @@ public class SpecializedElementsWithOnDiskTest {
 
         assertEquals(584, graph.traversal().V().hasLabel(Song.label).toList().size());
         assertEquals(142, graph.traversal().V().has(Song.PERFORMANCES, 1).toList().size());
+        assertEquals(142, graph.traversal().V().has(Song.PERFORMANCES, 1).hasLabel(Song.label).toList().size());
         assertEquals(142, graph.traversal().V().hasLabel(Song.label).has(Song.PERFORMANCES, 1).toList().size());
+        assertEquals(7047, graph.traversal().V().out().hasLabel(Song.label).toList().size());
+        assertEquals(1, graph.traversal().V(800).hasLabel(Song.label).toList().size());
+        assertEquals(5, graph.traversal().V(1).out().hasLabel(Song.label).toList().size());
+        assertEquals(0, graph.traversal().V().hasLabel(Song.label).hasLabel(Artist.label).toList().size());
+        assertEquals(808, graph.traversal().V().hasLabel(Song.label, Artist.label).toList().size());
 
         graph.close();
     }

--- a/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/SpecializedElementsWithOnDiskTest.java
+++ b/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/SpecializedElementsWithOnDiskTest.java
@@ -59,6 +59,16 @@ public class SpecializedElementsWithOnDiskTest {
     }
 
     @Test
+    /* ensure these are identical for both ondisk overflow enabled/disabled */
+    public void optimizationStrategyAffectedSteps() throws IOException {
+        TinkerGraph graph = newGratefulDeadGraphWithSpecializedElementsWithData();
+
+        assertEquals(584, graph.traversal().V().hasLabel(Song.label).toList().size());
+
+        graph.close();
+    }
+
+    @Test
     public void gratefulDeadGraph() throws IOException {
         TinkerGraph graph = newGratefulDeadGraphWithSpecializedElementsWithData();
 
@@ -344,15 +354,6 @@ public class SpecializedElementsWithOnDiskTest {
         }
 
         graph.close();
-    }
-
-
-    @Test
-    public void shouldUseLabelStrategy() throws IOException {
-        // TODO factor out in separate test
-        // TODO test in conjunction with more steps
-        TinkerGraph graph = newGratefulDeadGraphWithSpecializedElementsWithData();
-        System.out.println("returned " + graph.traversal().V().hasLabel(Song.label).toList().size() + " elements");
     }
 
     private TinkerGraph newGratefulDeadGraphWithSpecializedElements() {

--- a/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/SpecializedElementsWithOnDiskTest.java
+++ b/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/SpecializedElementsWithOnDiskTest.java
@@ -58,23 +58,33 @@ public class SpecializedElementsWithOnDiskTest {
         System.out.println("SpecializedElementsTest.simplisticTest " + edges);
     }
 
-
     @Test
     /* ensure these are identical for both ondisk overflow enabled/disabled */
     public void optimizationStrategyAffectedSteps() throws IOException {
         TinkerGraph graph = newGratefulDeadGraphWithSpecializedElementsWithData();
 
+        // using `g.V().hasLabel(lbl)` optimization
         assertEquals(584, graph.traversal().V().hasLabel(Song.label).toList().size());
         assertEquals(142, graph.traversal().V().has(Song.PERFORMANCES, 1).toList().size());
         assertEquals(142, graph.traversal().V().has(Song.PERFORMANCES, 1).hasLabel(Song.label).toList().size());
         assertEquals(142, graph.traversal().V().hasLabel(Song.label).has(Song.PERFORMANCES, 1).toList().size());
         assertEquals(7047, graph.traversal().V().out().hasLabel(Song.label).toList().size());
-        assertEquals(1, graph.traversal().V(800).hasLabel(Song.label).toList().size());
-        assertEquals(5, graph.traversal().V(1).out().hasLabel(Song.label).toList().size());
+        assertEquals(1, graph.traversal().V(800l).hasLabel(Song.label).toList().size());
+        assertEquals(5, graph.traversal().V(1l).out().hasLabel(Song.label).toList().size());
         assertEquals(0, graph.traversal().V().hasLabel(Song.label).hasLabel(Artist.label).toList().size());
         assertEquals(808, graph.traversal().V().hasLabel(Song.label, Artist.label).toList().size());
         assertEquals(501, graph.traversal().V().outE().hasLabel(WrittenBy.label).toList().size());
         assertEquals(501, graph.traversal().V().hasLabel(Song.label).outE().hasLabel(WrittenBy.label).toList().size());
+
+        // using `g.E().hasLabel(lbl)` optimization
+        assertEquals(8049, graph.traversal().E().toList().size());
+        assertEquals(7047, graph.traversal().E().hasLabel(FollowedBy.label).toList().size());
+        assertEquals(3564, graph.traversal().E().has(FollowedBy.WEIGHT, 1).toList().size());
+        assertEquals(3564, graph.traversal().E().hasLabel(FollowedBy.label).has(FollowedBy.WEIGHT, 1).toList().size());
+        assertEquals(3564, graph.traversal().E().has(FollowedBy.WEIGHT, 1).hasLabel(FollowedBy.label).toList().size());
+        assertEquals(7047, graph.traversal().E().hasLabel(FollowedBy.label).outV().hasLabel(Song.label).toList().size());
+        assertEquals(1, graph.traversal().E(0l).hasLabel(FollowedBy.label).toList().size());
+        assertEquals(7548, graph.traversal().E().hasLabel(FollowedBy.label, SungBy.label).toList().size());
 
         graph.close();
     }

--- a/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/SpecializedElementsWithOnDiskTest.java
+++ b/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/SpecializedElementsWithOnDiskTest.java
@@ -346,6 +346,15 @@ public class SpecializedElementsWithOnDiskTest {
         graph.close();
     }
 
+
+    @Test
+    public void shouldUseLabelStrategy() throws IOException {
+        // TODO factor out in separate test
+        // TODO test in conjunction with more steps
+        TinkerGraph graph = newGratefulDeadGraphWithSpecializedElementsWithData();
+        System.out.println("returned " + graph.traversal().V().hasLabel(Song.label).toList().size() + " elements");
+    }
+
     private TinkerGraph newGratefulDeadGraphWithSpecializedElements() {
         Configuration configuration = TinkerGraph.EMPTY_CONFIGURATION();
         configuration.setProperty(TinkerGraph.GREMLIN_TINKERGRAPH_ONDISK_OVERFLOW_ENABLED, true);

--- a/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/SpecializedElementsWithOnDiskTest.java
+++ b/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/SpecializedElementsWithOnDiskTest.java
@@ -58,6 +58,7 @@ public class SpecializedElementsWithOnDiskTest {
         System.out.println("SpecializedElementsTest.simplisticTest " + edges);
     }
 
+
     @Test
     /* ensure these are identical for both ondisk overflow enabled/disabled */
     public void optimizationStrategyAffectedSteps() throws IOException {

--- a/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/SpecializedElementsWithOnDiskTest.java
+++ b/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/SpecializedElementsWithOnDiskTest.java
@@ -73,6 +73,8 @@ public class SpecializedElementsWithOnDiskTest {
         assertEquals(5, graph.traversal().V(1).out().hasLabel(Song.label).toList().size());
         assertEquals(0, graph.traversal().V().hasLabel(Song.label).hasLabel(Artist.label).toList().size());
         assertEquals(808, graph.traversal().V().hasLabel(Song.label, Artist.label).toList().size());
+        assertEquals(501, graph.traversal().V().outE().hasLabel(WrittenBy.label).toList().size());
+        assertEquals(501, graph.traversal().V().hasLabel(Song.label).outE().hasLabel(WrittenBy.label).toList().size());
 
         graph.close();
     }


### PR DESCRIPTION
Prior to this, every traversal would iterate all elements, even if a `hasLabel` step was provided. This PR adds an optimization, but only for the on-disk overflow enabled graph (because that's where it matters most).