### PR TITLE
optimize array growth function (~8% less heap)

### DIFF
--- a/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/OverflowDbNode.java
+++ b/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/OverflowDbNode.java
@@ -572,7 +572,7 @@ public abstract class OverflowDbNode implements Vertex {
                                                       int insertAt,
                                                       int currentLength) {
     int currentCapacity = currentLength / strideSize;
-    double additionalCapacity = Math.sqrt(currentCapacity * 2) + 1;
+    double additionalCapacity = Math.sqrt(currentCapacity) + 1;
     int additionalCapacityInt = (int) Math.ceil(additionalCapacity);
     int additionalEntriesCount = additionalCapacityInt * strideSize;
     int newSize = adjacentVerticesWithProperties.length + additionalEntriesCount;

--- a/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/OverflowDbNode.java
+++ b/src/main/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/OverflowDbNode.java
@@ -64,9 +64,6 @@ public abstract class OverflowDbNode implements Vertex {
    * i.e. each outgoing edge type has two entries in this array. */
   private int[] edgeOffsets;
 
-  /* determines how many spaces for adjacent vertices will be left free, so we don't need to grow the array for every additional edge */
-  private static final int growthEmptyFactor = 2; // TODO make configurable
-
   /**
    * @param numberOfDifferentAdjacentTypes The number fo different IN|OUT edge relations. E.g. a node has AST edges in
    *                                       and out, then we would have 2. If in addition it has incoming
@@ -567,13 +564,17 @@ public abstract class OverflowDbNode implements Vertex {
    * grow the adjacentVerticesWithProperties array
    *
    * preallocates more space than immediately necessary, so we don't need to grow the array every time
-   * (tradeoff between performance and memory)
+   * (tradeoff between performance and memory).
+   * grows with the square root of the double of the current capacity.
    */
   private Object[] growAdjacentVerticesWithProperties(int offsetPos,
                                                       int strideSize,
                                                       int insertAt,
                                                       int currentLength) {
-    int additionalEntriesCount = (currentLength + strideSize) * growthEmptyFactor;
+    int currentCapacity = currentLength / strideSize;
+    double additionalCapacity = Math.sqrt(currentCapacity * 2) + 1;
+    int additionalCapacityInt = (int) Math.ceil(additionalCapacity);
+    int additionalEntriesCount = additionalCapacityInt * strideSize;
     int newSize = adjacentVerticesWithProperties.length + additionalEntriesCount;
     Object[] newArray = new Object[newSize];
     System.arraycopy(adjacentVerticesWithProperties, 0, newArray, 0, insertAt);

--- a/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/OverflowDbNodeTest.java
+++ b/src/test/java/org/apache/tinkerpop/gremlin/tinkergraph/structure/OverflowDbNodeTest.java
@@ -18,7 +18,6 @@
  */
 package org.apache.tinkerpop.gremlin.tinkergraph.structure;
 
-import org.apache.commons.lang3.NotImplementedException;
 import org.apache.tinkerpop.gremlin.structure.Direction;
 import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.T;
@@ -35,10 +34,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.__;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 public class OverflowDbNodeTest {
 


### PR DESCRIPTION
using square root when growing the arrays ensures that large arrays
don't end up with too big allocated (but free) spaces.

for openxava the heap usage reduces by 8%

local measurements suggested that cpg2sp actually runs slightly faster
than before, but that could be a glitch